### PR TITLE
This adds a check to see if the bundle includes logs

### DIFF
--- a/chef-server/controls/basic.rb
+++ b/chef-server/controls/basic.rb
@@ -22,6 +22,19 @@ control '000.gatherlogs.chef-server.package' do
   end
 end
 
+control 'gatherlogs.chef-server.includes_logs' do
+  title 'Check that the log bundle actually includes the opscode log directory'
+  desc "
+  The opscode log directory was missing from the log bundle. This can happen when
+  /var/log/opscode is a symlink to another location.
+  "
+
+  describe directory('var/log/opscode') do
+    it { should exist }
+  end
+end
+
+
 control 'gatherlogs.chef-server.postgreql-upgrade-applied' do
   title 'make sure customer is using chef-server version that includes postgresl 9.6'
   desc "

--- a/chef-server/inspec.yml
+++ b/chef-server/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: Chef InSpec profile for Chef-Server generated gather-logs
-version: 0.4.6
+version: 0.4.7
 
 depends:
   - name: glresources


### PR DESCRIPTION
Sometimes with chef-server if `/var/log/opscode` is a symlink to another
mount the `find` used to pull the logs won't grab anything because
it's nots configured to follow symlinks